### PR TITLE
Exception Cleanup

### DIFF
--- a/src/main/java/onespot/pivotal/api/PivotalTracker.java
+++ b/src/main/java/onespot/pivotal/api/PivotalTracker.java
@@ -1,7 +1,7 @@
 package onespot.pivotal.api;
 
 import com.google.common.collect.HashMultimap;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.dao.ProjectsDAO;
 import onespot.pivotal.api.resources.Me;
 import onespot.pivotal.rest.JsonRestClient;
@@ -22,11 +22,11 @@ public class PivotalTracker {
         this.jsonRestClient = jsonRestClient;
     }
 
-    public Me getMe() throws UnirestException {
+    public Me getMe() {
         return jsonRestClient.get(Me.class, "me", HashMultimap.create());
     }
 
-    public ProjectsDAO projects() throws UnirestException {
+    public ProjectsDAO projects() {
         return new ProjectsDAO(jsonRestClient, "projects", HashMultimap.create());
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/AbstractPaginatedDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/AbstractPaginatedDAO.java
@@ -1,12 +1,12 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.mashape.unirest.http.exceptions.UnirestException;
-import onespot.pivotal.rest.JsonRestClient;
-
 import java.lang.reflect.Type;
 import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+
+import onespot.pivotal.rest.JsonRestClient;
 
 /**
  * Created by ian on 3/30/15.
@@ -18,7 +18,7 @@ public abstract class AbstractPaginatedDAO<R> extends DAO {
         super(jsonRestClient, path, params);
     }
 
-    public List<R> get() throws UnirestException {
+    public List<R> get() {
         return jsonRestClient.get(getListTypeToken(), path, params);
     }
 
@@ -26,9 +26,8 @@ public abstract class AbstractPaginatedDAO<R> extends DAO {
      * Retrieve all items under this DAO using the pagination mechanism.
      * As this may require multiple calls to the pivotal API, it might take a while.
      * @return
-     * @throws UnirestException
      */
-    public List<R> getAll() throws UnirestException {
+    public List<R> getAll() {
         List<R> items = Lists.newArrayList();
         int position = 0;
         while (true) {

--- a/src/main/java/onespot/pivotal/api/dao/CommentsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/CommentsDAO.java
@@ -1,12 +1,12 @@
 package onespot.pivotal.api.dao;
 
+import java.util.List;
+
 import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Comment;
 import onespot.pivotal.rest.JsonRestClient;
-
-import java.util.List;
 
 /**
  * Created by ian on 3/30/15.
@@ -16,19 +16,19 @@ public class CommentsDAO extends DAO {
         super(jsonRestClient, pathPrefix, params);
     }
 
-    public List<Comment> get() throws UnirestException {
+    public List<Comment> get() {
         return jsonRestClient.get(new TypeToken<List<Comment>>(){}.getType(), path, params);
     }
 
-    public Comment get(int id) throws UnirestException {
+    public Comment get(int id) {
         return jsonRestClient.get(Comment.class, path+"/"+id, params);
     }
 
-    public void put(int id, Comment comment) throws UnirestException {
+    public void put(int id, Comment comment) {
         jsonRestClient.put(Comment.class, path+"/"+id, params, comment);
     }
 
-    public void post(Comment comment) throws UnirestException {
+    public void post(Comment comment) {
         jsonRestClient.post(Comment.class, path, params, comment);
     }
 }

--- a/src/main/java/onespot/pivotal/api/dao/EpicDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/EpicDAO.java
@@ -1,7 +1,7 @@
 package onespot.pivotal.api.dao;
 
 import com.google.common.collect.Multimap;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Epic;
 import onespot.pivotal.rest.JsonRestClient;
 
@@ -13,11 +13,11 @@ public class EpicDAO extends DAO {
         super(jsonRestClient, path, params);
     }
 
-    public Epic get() throws UnirestException {
+    public Epic get() {
         return jsonRestClient.get(Epic.class, path, params);
     }
 
-    public void put(Epic epic) throws UnirestException {
+    public void put(Epic epic) {
         jsonRestClient.put(Epic.class, path, params, epic);
     }
 }

--- a/src/main/java/onespot/pivotal/api/dao/EpicsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/EpicsDAO.java
@@ -1,13 +1,13 @@
 package onespot.pivotal.api.dao;
 
+import java.util.List;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Epic;
 import onespot.pivotal.rest.JsonRestClient;
-
-import java.util.List;
 
 /**
  * Created by ian on 4/3/15.
@@ -18,11 +18,11 @@ public class EpicsDAO extends DAO {
         super(jsonRestClient, path, params);
     }
 
-    public List<Epic> get() throws UnirestException {
+    public List<Epic> get() {
         return jsonRestClient.get(new TypeToken<List<Epic>>(){}.getType(), path, params);
     }
 
-    public EpicDAO id(int id) throws UnirestException {
+    public EpicDAO id(int id) {
         return new EpicDAO(jsonRestClient, "/"+id, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/LabelsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/LabelsDAO.java
@@ -1,13 +1,13 @@
 package onespot.pivotal.api.dao;
 
+import java.util.List;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Label;
 import onespot.pivotal.rest.JsonRestClient;
-
-import java.util.List;
 
 /**
  * Created by ian on 3/30/15.
@@ -17,11 +17,11 @@ public class LabelsDAO extends DAO {
         super(jsonRestClient, path, params);
     }
 
-    public List<Label> get() throws UnirestException {
+    public List<Label> get() {
         return jsonRestClient.get(new TypeToken<List<Label>>(){}.getType(), path, params);
     }
 
-    public Label get(int id) throws UnirestException {
+    public Label get(int id) {
         return jsonRestClient.get(Label.class, "/"+id, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/ProjectDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectDAO.java
@@ -1,7 +1,7 @@
 package onespot.pivotal.api.dao;
 
 import com.google.common.collect.Multimap;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Project;
 import onespot.pivotal.rest.JsonRestClient;
 
@@ -13,7 +13,7 @@ public class ProjectDAO extends DAO {
         super(jsonRestClient, pathPrefix, params);
     }
 
-    public Project get() throws UnirestException {
+    public Project get() {
         return jsonRestClient.get(Project.class, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/ProjectsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectsDAO.java
@@ -1,13 +1,13 @@
 package onespot.pivotal.api.dao;
 
+import java.util.List;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Project;
 import onespot.pivotal.rest.JsonRestClient;
-
-import java.util.List;
 
 /**
  * Created by ian on 3/29/15.
@@ -18,11 +18,11 @@ public class ProjectsDAO extends DAO {
         super(jsonRestClient, pathPrefix, params);
     }
 
-    public List<Project> id() throws UnirestException {
+    public List<Project> id() {
         return jsonRestClient.get(new TypeToken<List<Project>>(){}.getType(), path, params);
     }
 
-    public ProjectDAO id(int id) throws UnirestException {
+    public ProjectDAO id(int id) {
         return new ProjectDAO(jsonRestClient, path +"/"+id, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/StoriesDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/StoriesDAO.java
@@ -1,15 +1,15 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
-import com.google.gson.reflect.TypeToken;
-import com.mashape.unirest.http.exceptions.UnirestException;
-import onespot.pivotal.api.resources.Story;
-import onespot.pivotal.rest.JsonRestClient;
-
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Multimap;
+import com.google.gson.reflect.TypeToken;
+
+import onespot.pivotal.api.resources.Story;
+import onespot.pivotal.rest.JsonRestClient;
 
 /**
  * Created by ian on 3/29/15.
@@ -26,16 +26,16 @@ public class StoriesDAO extends AbstractPaginatedDAO<Story> {
     }
 
     @Override
-    public List<Story> get() throws UnirestException {
+    public List<Story> get() {
         return jsonRestClient.get(new TypeToken<List<Story>>() {
         }.getType(), path, params);
     }
 
-    public StoryDAO id(int id) throws UnirestException {
+    public StoryDAO id(int id) {
         return new StoryDAO(jsonRestClient, path + "/" + id, params);
     }
 
-    public void post(Story story) throws UnirestException {
+    public void post(Story story) {
         jsonRestClient.post(Story.class, path, params, story);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/StoryDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/StoryDAO.java
@@ -1,7 +1,7 @@
 package onespot.pivotal.api.dao;
 
 import com.google.common.collect.Multimap;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
 import onespot.pivotal.api.resources.Story;
 import onespot.pivotal.rest.JsonRestClient;
 
@@ -13,11 +13,11 @@ public class StoryDAO extends DAO {
         super(jsonRestClient, path, params);
     }
 
-    public Story get() throws UnirestException {
+    public Story get() {
         return jsonRestClient.get(Story.class, path, params);
     }
 
-    public void put(Story story) throws UnirestException {
+    public void put(Story story) {
         jsonRestClient.put(Story.class, path, params, story);
     }
 

--- a/src/main/java/onespot/pivotal/api/ex/PivotalAPIException.java
+++ b/src/main/java/onespot/pivotal/api/ex/PivotalAPIException.java
@@ -1,0 +1,24 @@
+package onespot.pivotal.api.ex;
+
+public class PivotalAPIException extends RuntimeException {
+	/**
+	 * The serial id.
+	 */
+	private static final long serialVersionUID = 4895542956126605694L;
+
+	public PivotalAPIException() {
+	        super();
+	    }
+
+	public PivotalAPIException(String message) {
+	        super(message);
+	    }
+
+	public PivotalAPIException(String message, Throwable cause) {
+	        super(message, cause);
+	    }
+
+	public PivotalAPIException(Throwable cause) {
+	        super(cause);
+	    }
+}

--- a/src/main/java/onespot/pivotal/rest/JsonRestClient.java
+++ b/src/main/java/onespot/pivotal/rest/JsonRestClient.java
@@ -1,14 +1,25 @@
 package onespot.pivotal.rest;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.gson.*;
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.exceptions.UnirestException;
-
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.LocalDate;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.mashape.unirest.http.HttpResponse;
+
+import onespot.pivotal.api.ex.PivotalAPIException;
 
 /**
  * Created by ian on 3/27/15.
@@ -67,13 +78,13 @@ public class JsonRestClient {
                 .create();
     }
 
-    public <T> T get(Class<T> cls, String path, Multimap<String, String> params) throws UnirestException {
+    public <T> T get(Class<T> cls, String path, Multimap<String, String> params) throws PivotalAPIException {
         HttpResponse<String> response = httpResponse(path, params);
         String body = extractBody(response);
         return gson.fromJson(body, cls);
     }
 
-    public <T> T get(Type cls, String path, Multimap<String, String> params) throws UnirestException {
+    public <T> T get(Type cls, String path, Multimap<String, String> params) throws PivotalAPIException {
         HttpResponse<String> response = httpResponse(path, params);
         try {
             String body = extractBody(response);
@@ -83,28 +94,28 @@ public class JsonRestClient {
         }
     }
 
-    public <T> T put(Type cls, String path, Multimap<String, String> params, T payload) throws UnirestException {
+    public <T> T put(Type cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.put(path, params, gson.toJson(payload))), cls);
     }
 
-    public <T> T put(Class<T> cls, String path, Multimap<String, String> params, T payload) throws UnirestException {
+    public <T> T put(Class<T> cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.put(path, params, gson.toJson(payload))), cls);
     }
 
-    public <T> T post(Class<T> cls, String path, Multimap<String, String> params, T payload) throws UnirestException {
+    public <T> T post(Class<T> cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
         String payloadJson = gson.toJson(payload);
         return gson.fromJson(extractBody(restClient.post(path, params, payloadJson)), cls);
     }
 
-    public <T> T post(Type cls, String path, Multimap<String, String> params, T payload) throws UnirestException {
+    public <T> T post(Type cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.post(path, params, gson.toJson(payload))), cls);
     }
 
-    public <T> T delete(Class<T> cls, String path, Multimap<String, String> params) throws UnirestException {
+    public <T> T delete(Class<T> cls, String path, Multimap<String, String> params) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.delete(path, params)), cls);
     }
 
-    public <T> T delete(Type cls, String path, Multimap<String, String> params) throws UnirestException {
+    public <T> T delete(Type cls, String path, Multimap<String, String> params) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.delete(path, params)), cls);
     }
 
@@ -119,11 +130,11 @@ public class JsonRestClient {
 
 
 
-    private HttpResponse<String> httpResponse(String path) throws UnirestException {
+    private HttpResponse<String> httpResponse(String path) {
         return httpResponse(path, HashMultimap.create());
     }
 
-    private HttpResponse<String> httpResponse(String path, Multimap<String, String> params) throws UnirestException {
-        return restClient.get(path, params);
+    private HttpResponse<String> httpResponse(String path, Multimap<String, String> params) throws PivotalAPIException {
+    	return restClient.get(path, params);
     }
 }

--- a/src/main/java/onespot/pivotal/rest/PivotalRestClient.java
+++ b/src/main/java/onespot/pivotal/rest/PivotalRestClient.java
@@ -1,13 +1,15 @@
 package onespot.pivotal.rest;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import onespot.pivotal.api.ex.PivotalAPIException;
 
 /**
  * Created by ian on 3/23/15.
@@ -21,12 +23,16 @@ public class PivotalRestClient implements RestClient {
     }
 
     @Override
-    public HttpResponse<String> get(String path, Multimap<String, String> params) throws UnirestException {
+    public HttpResponse<String> get(String path, Multimap<String, String> params) throws PivotalAPIException {
         String parameters = paramsToStringWithoutURLEncoding(params);
 
         String url = URL_PREFIX+"/"+path+"?"+parameters;
 
-        return Unirest.get(url).header("X-TrackerToken", apiToken).asString();
+        try {
+			return Unirest.get(url).header("X-TrackerToken", apiToken).asString();
+		} catch (UnirestException uex) {
+			throw new PivotalAPIException(uex);
+		}
     }
 
     /*
@@ -48,25 +54,37 @@ public class PivotalRestClient implements RestClient {
 
 
     @Override
-    public HttpResponse<String> put(String path, com.google.common.collect.Multimap<String, String> params, String payload) throws UnirestException {
-        return Unirest.put(URL_PREFIX+ "/" + path).header("X-TrackerToken", apiToken)
-                .header("Content-Type", "application/json")
-                .body(payload).asString();
+    public HttpResponse<String> put(String path, com.google.common.collect.Multimap<String, String> params, String payload) throws PivotalAPIException {
+        try {
+			return Unirest.put(URL_PREFIX+ "/" + path).header("X-TrackerToken", apiToken)
+			        .header("Content-Type", "application/json")
+			        .body(payload).asString();
+		} catch (UnirestException uex) {
+			throw new PivotalAPIException(uex);
+		}
     }
 
 
     @Override
-    public HttpResponse<String> post(String path, com.google.common.collect.Multimap<String, String> params, String payload) throws UnirestException {
+    public HttpResponse<String> post(String path, com.google.common.collect.Multimap<String, String> params, String payload) throws PivotalAPIException {
         String url = URL_PREFIX + "/" + path;
-        return Unirest.post(url).header("X-TrackerToken", apiToken)
-                .header("Content-Type", "application/json")
-                .body(payload).asString();
+        try {
+			return Unirest.post(url).header("X-TrackerToken", apiToken)
+			        .header("Content-Type", "application/json")
+			        .body(payload).asString();
+		} catch (UnirestException uex) {
+			throw new PivotalAPIException(uex);
+		}
     }
 
 
     @Override
-    public HttpResponse<String> delete(String path, com.google.common.collect.Multimap<String, String> params) throws UnirestException {
-        return Unirest.delete(URL_PREFIX + "/" + path).header("X-TrackerToken", apiToken).asString();
+    public HttpResponse<String> delete(String path, com.google.common.collect.Multimap<String, String> params) throws PivotalAPIException {
+        try {
+			return Unirest.delete(URL_PREFIX + "/" + path).header("X-TrackerToken", apiToken).asString();
+		} catch (UnirestException uex) {
+			throw new PivotalAPIException(uex);
+		}
     }
 
 }

--- a/src/main/java/onespot/pivotal/rest/RestClient.java
+++ b/src/main/java/onespot/pivotal/rest/RestClient.java
@@ -2,17 +2,18 @@ package onespot.pivotal.rest;
 
 import com.google.common.collect.Multimap;
 import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.exceptions.UnirestException;
+
+import onespot.pivotal.api.ex.PivotalAPIException;
 
 /**
  * Created by ian on 3/27/15.
  */
 public interface RestClient {
-    HttpResponse<String> get(String path, Multimap<String, String> params) throws UnirestException;
+    HttpResponse<String> get(String path, Multimap<String, String> params) throws PivotalAPIException;
 
-    HttpResponse<String> put(String path, Multimap<String, String> params, String payload) throws UnirestException;
+    HttpResponse<String> put(String path, Multimap<String, String> params, String payload) throws PivotalAPIException;
 
-    HttpResponse<String> post(String path, Multimap<String, String> params, String payload) throws UnirestException;
+    HttpResponse<String> post(String path, Multimap<String, String> params, String payload) throws PivotalAPIException;
 
-    HttpResponse<String> delete(String path, Multimap<String, String> params) throws UnirestException;
+    HttpResponse<String> delete(String path, Multimap<String, String> params) throws PivotalAPIException;
 }


### PR DESCRIPTION
Currently API is heavily using check exceptions, mostly the `UnirestException`, which makes the change of underlying rest client impossible and moreover the usage of  check exceptions makes the api hard to use when used in Java 8 Functional Programming.

So just created API internal representation of API exception `PivotalAPIException`  and removed the use of `UnirestException` from all places which were not directly dependant on it.

With this PR we can get more flexible API client (the unirest can be changed without API change) and less try catch blocks in code where it should not fail.
