### PR TITLE
Parameters Map Implementation

### DIFF
--- a/src/main/java/onespot/pivotal/api/PivotalTracker.java
+++ b/src/main/java/onespot/pivotal/api/PivotalTracker.java
@@ -1,6 +1,6 @@
 package onespot.pivotal.api;
 
-import com.google.common.collect.HashMultimap;
+import java.util.HashMap;
 
 import onespot.pivotal.api.dao.ProjectsDAO;
 import onespot.pivotal.api.resources.Me;
@@ -23,11 +23,11 @@ public class PivotalTracker {
     }
 
     public Me getMe() {
-        return jsonRestClient.get(Me.class, "me", HashMultimap.create());
+        return jsonRestClient.get(Me.class, "me", new HashMap<>());
     }
 
     public ProjectsDAO projects() {
-        return new ProjectsDAO(jsonRestClient, "projects", HashMultimap.create());
+        return new ProjectsDAO(jsonRestClient, "projects", new HashMap<>());
     }
 
 

--- a/src/main/java/onespot/pivotal/api/dao/AbstractPaginatedDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/AbstractPaginatedDAO.java
@@ -2,9 +2,9 @@ package onespot.pivotal.api.dao;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 
 import onespot.pivotal.rest.JsonRestClient;
 
@@ -14,7 +14,7 @@ import onespot.pivotal.rest.JsonRestClient;
 public abstract class AbstractPaginatedDAO<R> extends DAO {
     protected abstract Type getListTypeToken();
 
-    public AbstractPaginatedDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public AbstractPaginatedDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/ActivitiesDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ActivitiesDAO.java
@@ -1,18 +1,19 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.Multimap;
-import com.google.gson.reflect.TypeToken;
-import onespot.pivotal.api.resources.Activity;
-import onespot.pivotal.rest.JsonRestClient;
-
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
+
+import com.google.gson.reflect.TypeToken;
+
+import onespot.pivotal.api.resources.Activity;
+import onespot.pivotal.rest.JsonRestClient;
 
 /**
  * Created by ian on 4/1/15.
  */
 public class ActivitiesDAO extends AbstractPaginatedDAO<Activity> {
-    public ActivitiesDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public ActivitiesDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/CommentsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/CommentsDAO.java
@@ -1,8 +1,8 @@
 package onespot.pivotal.api.dao;
 
 import java.util.List;
+import java.util.Map;
 
-import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
 
 import onespot.pivotal.api.resources.Comment;
@@ -12,7 +12,7 @@ import onespot.pivotal.rest.JsonRestClient;
  * Created by ian on 3/30/15.
  */
 public class CommentsDAO extends DAO {
-    public CommentsDAO(JsonRestClient jsonRestClient, String pathPrefix, Multimap<String, String> params) {
+    public CommentsDAO(JsonRestClient jsonRestClient, String pathPrefix, Map<String, String> params) {
         super(jsonRestClient, pathPrefix, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/DAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/DAO.java
@@ -1,7 +1,8 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import java.util.HashMap;
+import java.util.Map;
+
 import onespot.pivotal.rest.JsonRestClient;
 
 /**
@@ -10,11 +11,11 @@ import onespot.pivotal.rest.JsonRestClient;
 public abstract class DAO {
     protected final JsonRestClient jsonRestClient;
     protected final String path;
-    protected Multimap<String, String> params;
+    protected Map<String, String> params;
 
-    public DAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public DAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         this.jsonRestClient = jsonRestClient;
         this.path = path;
-        this.params = HashMultimap.create(params);
+        this.params = new HashMap<>(params);
     }
 }

--- a/src/main/java/onespot/pivotal/api/dao/EpicDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/EpicDAO.java
@@ -1,6 +1,6 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.Multimap;
+import java.util.Map;
 
 import onespot.pivotal.api.resources.Epic;
 import onespot.pivotal.rest.JsonRestClient;
@@ -9,7 +9,7 @@ import onespot.pivotal.rest.JsonRestClient;
  * Created by ian on 3/29/15.
  */
 public class EpicDAO extends DAO {
-    public EpicDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public EpicDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/EpicsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/EpicsDAO.java
@@ -1,9 +1,9 @@
 package onespot.pivotal.api.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
 
 import onespot.pivotal.api.resources.Epic;
@@ -14,7 +14,7 @@ import onespot.pivotal.rest.JsonRestClient;
  */
 public class EpicsDAO extends DAO {
 
-    public EpicsDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public EpicsDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/IterationsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/IterationsDAO.java
@@ -1,19 +1,20 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
-import com.google.gson.reflect.TypeToken;
-import onespot.pivotal.api.resources.Iteration;
-import onespot.pivotal.rest.JsonRestClient;
-
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Joiner;
+import com.google.gson.reflect.TypeToken;
+
+import onespot.pivotal.api.resources.Iteration;
+import onespot.pivotal.rest.JsonRestClient;
 
 /**
  * Created by ian on 3/30/15.
  */
 public class IterationsDAO extends AbstractPaginatedDAO<Iteration> {
-    public IterationsDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public IterationsDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/LabelsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/LabelsDAO.java
@@ -1,9 +1,9 @@
 package onespot.pivotal.api.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
 
 import onespot.pivotal.api.resources.Label;
@@ -13,7 +13,7 @@ import onespot.pivotal.rest.JsonRestClient;
  * Created by ian on 3/30/15.
  */
 public class LabelsDAO extends DAO {
-    public LabelsDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public LabelsDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/OwnersDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/OwnersDAO.java
@@ -1,13 +1,14 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.Multimap;
+import java.util.Map;
+
 import onespot.pivotal.rest.JsonRestClient;
 
 /**
  * Created by ian on 3/30/15.
  */
 public class OwnersDAO extends DAO {
-    public OwnersDAO(JsonRestClient jsonRestClient, String pathPrefix, Multimap<String, String> params) {
+    public OwnersDAO(JsonRestClient jsonRestClient, String pathPrefix, Map<String, String> params) {
         super(jsonRestClient, pathPrefix, params);
     }
 }

--- a/src/main/java/onespot/pivotal/api/dao/ProjectDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectDAO.java
@@ -1,6 +1,6 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.Multimap;
+import java.util.Map;
 
 import onespot.pivotal.api.resources.Project;
 import onespot.pivotal.rest.JsonRestClient;
@@ -9,7 +9,7 @@ import onespot.pivotal.rest.JsonRestClient;
  * Created by ian on 3/29/15.
  */
 public class ProjectDAO extends DAO {
-    public ProjectDAO(JsonRestClient jsonRestClient, String pathPrefix, Multimap<String, String> params) {
+    public ProjectDAO(JsonRestClient jsonRestClient, String pathPrefix, Map<String, String> params) {
         super(jsonRestClient, pathPrefix, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/ProjectsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectsDAO.java
@@ -1,9 +1,9 @@
 package onespot.pivotal.api.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
 
 import onespot.pivotal.api.resources.Project;
@@ -14,7 +14,7 @@ import onespot.pivotal.rest.JsonRestClient;
  */
 public class ProjectsDAO extends DAO {
 
-    public ProjectsDAO(JsonRestClient jsonRestClient, String pathPrefix, Multimap<String, String> params) {
+    public ProjectsDAO(JsonRestClient jsonRestClient, String pathPrefix, Map<String, String> params) {
         super(jsonRestClient, pathPrefix, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/StoriesDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/StoriesDAO.java
@@ -3,9 +3,9 @@ package onespot.pivotal.api.dao;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
 import com.google.gson.reflect.TypeToken;
 
 import onespot.pivotal.api.resources.Story;
@@ -15,7 +15,7 @@ import onespot.pivotal.rest.JsonRestClient;
  * Created by ian on 3/29/15.
  */
 public class StoriesDAO extends AbstractPaginatedDAO<Story> {
-    public StoriesDAO(JsonRestClient jsonRestClient, String pathPrefix, Multimap<String, String> params) {
+    public StoriesDAO(JsonRestClient jsonRestClient, String pathPrefix, Map<String, String> params) {
         super(jsonRestClient, pathPrefix, params);
     }
 

--- a/src/main/java/onespot/pivotal/api/dao/StoryDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/StoryDAO.java
@@ -1,6 +1,6 @@
 package onespot.pivotal.api.dao;
 
-import com.google.common.collect.Multimap;
+import java.util.Map;
 
 import onespot.pivotal.api.resources.Story;
 import onespot.pivotal.rest.JsonRestClient;
@@ -9,7 +9,7 @@ import onespot.pivotal.rest.JsonRestClient;
  * Created by ian on 3/29/15.
  */
 public class StoryDAO extends DAO {
-    public StoryDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+    public StoryDAO(JsonRestClient jsonRestClient, String path, Map<String, String> params) {
         super(jsonRestClient, path, params);
     }
 

--- a/src/main/java/onespot/pivotal/rest/JsonRestClient.java
+++ b/src/main/java/onespot/pivotal/rest/JsonRestClient.java
@@ -3,9 +3,9 @@ package onespot.pivotal.rest;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -78,13 +78,13 @@ public class JsonRestClient {
                 .create();
     }
 
-    public <T> T get(Class<T> cls, String path, Multimap<String, String> params) throws PivotalAPIException {
+    public <T> T get(Class<T> cls, String path, HashMap<String, String> params) throws PivotalAPIException {
         HttpResponse<String> response = httpResponse(path, params);
         String body = extractBody(response);
         return gson.fromJson(body, cls);
     }
 
-    public <T> T get(Type cls, String path, Multimap<String, String> params) throws PivotalAPIException {
+    public <T> T get(Type cls, String path, Map<String, String> params) throws PivotalAPIException {
         HttpResponse<String> response = httpResponse(path, params);
         try {
             String body = extractBody(response);
@@ -94,32 +94,30 @@ public class JsonRestClient {
         }
     }
 
-    public <T> T put(Type cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
+    public <T> T put(Type cls, String path, Map<String, String> params, T payload) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.put(path, params, gson.toJson(payload))), cls);
     }
 
-    public <T> T put(Class<T> cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
+    public <T> T put(Class<T> cls, String path, Map<String, String> params, T payload) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.put(path, params, gson.toJson(payload))), cls);
     }
 
-    public <T> T post(Class<T> cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
+    public <T> T post(Class<T> cls, String path, Map<String, String> params, T payload) throws PivotalAPIException {
         String payloadJson = gson.toJson(payload);
         return gson.fromJson(extractBody(restClient.post(path, params, payloadJson)), cls);
     }
 
-    public <T> T post(Type cls, String path, Multimap<String, String> params, T payload) throws PivotalAPIException {
+    public <T> T post(Type cls, String path, Map<String, String> params, T payload) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.post(path, params, gson.toJson(payload))), cls);
     }
 
-    public <T> T delete(Class<T> cls, String path, Multimap<String, String> params) throws PivotalAPIException {
+    public <T> T delete(Class<T> cls, String path, Map<String, String> params) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.delete(path, params)), cls);
     }
 
-    public <T> T delete(Type cls, String path, Multimap<String, String> params) throws PivotalAPIException {
+    public <T> T delete(Type cls, String path, Map<String, String> params) throws PivotalAPIException {
         return gson.fromJson(extractBody(restClient.delete(path, params)), cls);
     }
-
-
 
     private String extractBody(HttpResponse<String> response) {
         if (response.getStatus() != 200) {
@@ -128,13 +126,7 @@ public class JsonRestClient {
         return response.getBody();
     }
 
-
-
-    private HttpResponse<String> httpResponse(String path) {
-        return httpResponse(path, HashMultimap.create());
-    }
-
-    private HttpResponse<String> httpResponse(String path, Multimap<String, String> params) throws PivotalAPIException {
+    private HttpResponse<String> httpResponse(String path, Map<String, String> params) throws PivotalAPIException {
     	return restClient.get(path, params);
     }
 }

--- a/src/main/java/onespot/pivotal/rest/PivotalRestClient.java
+++ b/src/main/java/onespot/pivotal/rest/PivotalRestClient.java
@@ -1,10 +1,10 @@
 package onespot.pivotal.rest;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Multimap;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
@@ -23,7 +23,7 @@ public class PivotalRestClient implements RestClient {
     }
 
     @Override
-    public HttpResponse<String> get(String path, Multimap<String, String> params) throws PivotalAPIException {
+    public HttpResponse<String> get(String path, Map<String, String> params) throws PivotalAPIException {
         String parameters = paramsToStringWithoutURLEncoding(params);
 
         String url = URL_PREFIX+"/"+path+"?"+parameters;
@@ -44,8 +44,8 @@ public class PivotalRestClient implements RestClient {
      * TODO: Figure out what the actual standard is, which hopefully permits
      *       commas in query parameter values, and enforce that.
      */
-    private String paramsToStringWithoutURLEncoding(Multimap<String, String> params) {
-        List<String> parameterList = params.entries().stream()
+    private String paramsToStringWithoutURLEncoding(Map<String, String> params) {
+    	List<String> parameterList = params.entrySet().stream()
                 .map(entry -> entry.getKey()+"="+entry.getValue())
                 .collect(Collectors.toList());
 
@@ -54,7 +54,7 @@ public class PivotalRestClient implements RestClient {
 
 
     @Override
-    public HttpResponse<String> put(String path, com.google.common.collect.Multimap<String, String> params, String payload) throws PivotalAPIException {
+    public HttpResponse<String> put(String path, Map<String, String> params, String payload) throws PivotalAPIException {
         try {
 			return Unirest.put(URL_PREFIX+ "/" + path).header("X-TrackerToken", apiToken)
 			        .header("Content-Type", "application/json")
@@ -66,7 +66,7 @@ public class PivotalRestClient implements RestClient {
 
 
     @Override
-    public HttpResponse<String> post(String path, com.google.common.collect.Multimap<String, String> params, String payload) throws PivotalAPIException {
+    public HttpResponse<String> post(String path, Map<String, String> params, String payload) throws PivotalAPIException {
         String url = URL_PREFIX + "/" + path;
         try {
 			return Unirest.post(url).header("X-TrackerToken", apiToken)
@@ -79,7 +79,7 @@ public class PivotalRestClient implements RestClient {
 
 
     @Override
-    public HttpResponse<String> delete(String path, com.google.common.collect.Multimap<String, String> params) throws PivotalAPIException {
+    public HttpResponse<String> delete(String path, Map<String, String> params) throws PivotalAPIException {
         try {
 			return Unirest.delete(URL_PREFIX + "/" + path).header("X-TrackerToken", apiToken).asString();
 		} catch (UnirestException uex) {

--- a/src/main/java/onespot/pivotal/rest/RestClient.java
+++ b/src/main/java/onespot/pivotal/rest/RestClient.java
@@ -1,6 +1,7 @@
 package onespot.pivotal.rest;
 
-import com.google.common.collect.Multimap;
+import java.util.Map;
+
 import com.mashape.unirest.http.HttpResponse;
 
 import onespot.pivotal.api.ex.PivotalAPIException;
@@ -9,11 +10,11 @@ import onespot.pivotal.api.ex.PivotalAPIException;
  * Created by ian on 3/27/15.
  */
 public interface RestClient {
-    HttpResponse<String> get(String path, Multimap<String, String> params) throws PivotalAPIException;
+    HttpResponse<String> get(String path, Map<String, String> params) throws PivotalAPIException;
 
-    HttpResponse<String> put(String path, Multimap<String, String> params, String payload) throws PivotalAPIException;
+    HttpResponse<String> put(String path, Map<String, String> params, String payload) throws PivotalAPIException;
 
-    HttpResponse<String> post(String path, Multimap<String, String> params, String payload) throws PivotalAPIException;
+    HttpResponse<String> post(String path, Map<String, String> params, String payload) throws PivotalAPIException;
 
-    HttpResponse<String> delete(String path, Multimap<String, String> params) throws PivotalAPIException;
+    HttpResponse<String> delete(String path, Map<String, String> params) throws PivotalAPIException;
 }


### PR DESCRIPTION
The usage of parameters as Guava MultiMap leads to a big problems.
For example `AbstractPaginatedDAO.getAll()` or any usage of `limit` or `offset` as the query params with the big data become unpredictable as the request url become something like this `offset=100&&offset=300&offset=200`
