### PR TITLE
Add project memberships endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 sourceCompatibility = 1.8
-version = '0.0.9'
+version = '0.0.10'
 
 repositories {
     mavenCentral()

--- a/src/main/java/onespot/pivotal/api/dao/OwnersDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/OwnersDAO.java
@@ -1,7 +1,12 @@
 package onespot.pivotal.api.dao;
 
 import com.google.common.collect.Multimap;
+import com.google.gson.reflect.TypeToken;
+import onespot.pivotal.api.resources.Person;
 import onespot.pivotal.rest.JsonRestClient;
+
+import java.lang.reflect.Type;
+import java.util.List;
 
 /**
  * Created by ian on 3/30/15.
@@ -9,5 +14,14 @@ import onespot.pivotal.rest.JsonRestClient;
 public class OwnersDAO extends DAO {
     public OwnersDAO(JsonRestClient jsonRestClient, String pathPrefix, Multimap<String, String> params) {
         super(jsonRestClient, pathPrefix, params);
+    }
+
+    protected Type getListTypeToken() {
+        return (new TypeToken<List<Person>>() {
+        }).getType();
+    }
+
+    public List<Person> getAll() {
+        return this.jsonRestClient.get(getListTypeToken(), this.path, this.params);
     }
 }

--- a/src/main/java/onespot/pivotal/api/dao/ProjectDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectDAO.java
@@ -1,7 +1,6 @@
 package onespot.pivotal.api.dao;
 
 import com.google.common.collect.Multimap;
-
 import onespot.pivotal.api.resources.Project;
 import onespot.pivotal.rest.JsonRestClient;
 
@@ -17,22 +16,26 @@ public class ProjectDAO extends DAO {
         return jsonRestClient.get(Project.class, path, params);
     }
 
-    public StoriesDAO stories()  {
-        return new StoriesDAO(jsonRestClient, path +"/stories", params);
+    public StoriesDAO stories() {
+        return new StoriesDAO(jsonRestClient, path + "/stories", params);
     }
 
-    public IterationsDAO iterations()  {
+    public ProjectMembershipsDAO memberships() {
+        return new ProjectMembershipsDAO(jsonRestClient, path + "/memberships", params);
+    }
+
+    public IterationsDAO iterations() {
         return new IterationsDAO(jsonRestClient, path + "/iterations", params);
     }
 
-    public LabelsDAO labels()  {
-        return new LabelsDAO(jsonRestClient, path+"/labels", params);
+    public LabelsDAO labels() {
+        return new LabelsDAO(jsonRestClient, path + "/labels", params);
     }
 
-    public EpicsDAO epics()  {
-        return new EpicsDAO(jsonRestClient, path+"/epics", params);
+    public EpicsDAO epics() {
+        return new EpicsDAO(jsonRestClient, path + "/epics", params);
     }
-    
+
     public ActivitiesDAO activity() {
         return new ActivitiesDAO(jsonRestClient, path + "/activity", params);
     }

--- a/src/main/java/onespot/pivotal/api/dao/ProjectMembershipDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectMembershipDAO.java
@@ -1,0 +1,20 @@
+package onespot.pivotal.api.dao;
+
+import com.google.common.collect.Multimap;
+import onespot.pivotal.api.resources.ProjectMembership;
+import onespot.pivotal.rest.JsonRestClient;
+
+/**
+ * Author: Arthur Halet
+ * Date: 12/07/2016
+ */
+public class ProjectMembershipDAO extends DAO {
+    public ProjectMembershipDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+        super(jsonRestClient, path, params);
+    }
+
+    public ProjectMembership get() {
+        System.out.println(this.path);
+        return (ProjectMembership) this.jsonRestClient.get(ProjectMembership.class, this.path, this.params);
+    }
+}

--- a/src/main/java/onespot/pivotal/api/dao/ProjectMembershipsDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/ProjectMembershipsDAO.java
@@ -1,0 +1,44 @@
+package onespot.pivotal.api.dao;
+
+import com.google.common.collect.Multimap;
+import com.google.gson.reflect.TypeToken;
+import onespot.pivotal.api.resources.ProjectMembership;
+import onespot.pivotal.api.resources.Story;
+import onespot.pivotal.rest.JsonRestClient;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Author: Arthur Halet
+ * Date: 12/07/2016
+ */
+public class ProjectMembershipsDAO extends DAO {
+
+
+    public ProjectMembershipsDAO(JsonRestClient jsonRestClient, String path, Multimap<String, String> params) {
+        super(jsonRestClient, path, params);
+    }
+
+    public ProjectMembershipDAO id(int id) {
+        return new ProjectMembershipDAO(this.jsonRestClient, this.path + "/" + id, this.params);
+    }
+
+    public ProjectMembership getMembershipFromStory(Story story) {
+        for (ProjectMembership membership : getAll()) {
+            if (membership.getPerson().id == story.requestedById) {
+                return membership;
+            }
+        }
+        return null;
+    }
+
+    protected Type getListTypeToken() {
+        return (new TypeToken<List<ProjectMembership>>() {
+        }).getType();
+    }
+
+    public List<ProjectMembership> getAll() {
+        return this.jsonRestClient.get(getListTypeToken(), this.path, this.params);
+    }
+}

--- a/src/main/java/onespot/pivotal/api/dao/StoryDAO.java
+++ b/src/main/java/onespot/pivotal/api/dao/StoryDAO.java
@@ -1,7 +1,7 @@
 package onespot.pivotal.api.dao;
 
 import com.google.common.collect.Multimap;
-
+import onespot.pivotal.api.resources.ProjectMembership;
 import onespot.pivotal.api.resources.Story;
 import onespot.pivotal.rest.JsonRestClient;
 
@@ -29,6 +29,14 @@ public class StoryDAO extends DAO {
         return new CommentsDAO(jsonRestClient, path + "/comments", params);
     }
 
+    public ProjectMembership requester() {
+        String[] pathSplitted = this.path.split("/");
+        pathSplitted[pathSplitted.length - 1] = "memberships";
+        String membershipsPath = String.join("/", pathSplitted);
+        ProjectMembershipsDAO projectMembershipsDAO = new ProjectMembershipsDAO(jsonRestClient, membershipsPath, params);
+        Story story = this.get();
+        return projectMembershipsDAO.getMembershipFromStory(story);
+    }
 
     public ActivitiesDAO activity() {
         return new ActivitiesDAO(jsonRestClient, path + "/activity", params);

--- a/src/main/java/onespot/pivotal/api/resources/ProjectMembership.java
+++ b/src/main/java/onespot/pivotal/api/resources/ProjectMembership.java
@@ -1,0 +1,121 @@
+package onespot.pivotal.api.resources;
+
+import java.time.Instant;
+
+/**
+ * Author: Arthur Halet
+ * Date: 12/07/2016
+ */
+public class ProjectMembership {
+    public Integer id;
+    public String name;
+    public String kind;
+    public Person person;
+    public Instant createdAt;
+    public Instant lastViewedAt;
+    public Instant updatedAt;
+    public int projectId;
+    public String projectColor;
+    public String role;
+    public boolean wantsCommentNotificationEmails;
+    public boolean willReceiveMentionNotificationsOrEmails;
+
+    public ProjectMembership() {
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public Person getPerson() {
+        return person;
+    }
+
+    public void setPerson(Person person) {
+        this.person = person;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getLastViewedAt() {
+        return lastViewedAt;
+    }
+
+    public void setLastViewedAt(Instant lastViewedAt) {
+        this.lastViewedAt = lastViewedAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public int getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(int projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getProjectColor() {
+        return projectColor;
+    }
+
+    public void setProjectColor(String projectColor) {
+        this.projectColor = projectColor;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public boolean isWantsCommentNotificationEmails() {
+        return wantsCommentNotificationEmails;
+    }
+
+    public void setWantsCommentNotificationEmails(boolean wantsCommentNotificationEmails) {
+        this.wantsCommentNotificationEmails = wantsCommentNotificationEmails;
+    }
+
+    public boolean isWillReceiveMentionNotificationsOrEmails() {
+        return willReceiveMentionNotificationsOrEmails;
+    }
+
+    public void setWillReceiveMentionNotificationsOrEmails(boolean willReceiveMentionNotificationsOrEmails) {
+        this.willReceiveMentionNotificationsOrEmails = willReceiveMentionNotificationsOrEmails;
+    }
+}


### PR DESCRIPTION
Hello, first thank you for the work, I've made a little contribution to add project memberships endpoint.

It's following the project membership api endpoint: https://www.pivotaltracker.com/help/api/rest/v5#Project_Memberships

My usecase was to retrieve the person who post the story as a Person object instead of only requester by id.

There is no endpoint to find a person on the api, project memberships was the closest endpoint to achieve this goal. It will give also all membership (With Personobject inside) who are in the project.
